### PR TITLE
ci/manifest enforcement

### DIFF
--- a/.github/workflows/manifest-check.yml
+++ b/.github/workflows/manifest-check.yml
@@ -1,0 +1,44 @@
+name: Manifest Check
+
+"on":
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'data/**'
+      - '.github/workflows/manifest-check.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'scripts/**'
+      - 'data/**'
+      - '.github/workflows/manifest-check.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Generate manifest
+        run: python scripts/generate_manifest.py
+      - name: Check if manifest is up-to-date
+        run: |
+          if ! git diff --quiet -- data/manifest.json; then
+            echo "❌ Manifest is out of date!"
+            echo ""
+            echo "The generated manifest differs from the committed version."
+            echo ""
+            echo "To fix this:"
+            echo "  1. Run 'python scripts/generate_manifest.py' locally"
+            echo "  2. Commit the updated data/manifest.json"
+            echo ""
+            echo "OR install pre-commit hooks to auto-generate on commit:"
+            echo "  - Run 'pre-commit install'"
+            echo "  - Pre-commit will auto-generate and stage the manifest"
+            echo ""
+            echo "Diff:"
+            git diff -- data/manifest.json
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,29 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-json
+        types: [file]  # override `types: [json]`
+        files: \.(json)$
+      - id: pretty-format-json
+        args: ['--autofix', '--no-sort-keys']
+        types: [file]  # override `types: [json]`
+        files: \.(json)$
+  - repo: local
+    hooks:
+      - id: generate-manifest
+        name: Generate data/manifest.json
+        language: system
+        entry: |
+          bash -lc '
+            python3 scripts/generate_manifest.py
+            if ! git diff --quiet -- data/manifest.json; then
+              git add data/manifest.json
+            fi
+          '
+        pass_filenames: false
+        always_run: true
+repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         args: ['--autofix', '--no-sort-keys']
         types: [file]  # override `types: [json]`
         files: \.(json)$
+        exclude: ^data/manifest\.json$
   - repo: local
     hooks:
       - id: generate-manifest
@@ -23,14 +24,3 @@ repos:
           '
         pass_filenames: false
         always_run: true
-repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
-  hooks:
-  - id: check-json
-    types: [file]  # override `types: [json]`
-    files: \.(json)$
-  - id: pretty-format-json
-    args: ['--autofix', '--no-sort-keys']
-    types: [file]  # override `types: [json]`
-    files: \.(json)$

--- a/README.md
+++ b/README.md
@@ -19,23 +19,6 @@ Fetch the data by retrieving the url:
 * `{simId}` is the Simhub game id `DataCorePlugin.CurrentGame`
 * `{trackId}` is the Simhub track id `DataCorePlugin.TrackId`
 
-### Manifest
-A single root manifest at `data/manifest.json` lists all tracks, grouped by game.
-
-Structure:
-```
-{
-  "tracks": {
-    "{simId}": [
-      { "trackName": "...", "trackId": "...", "path": "{simId}/...json" }
-    ]
-  }
-}
-```
-
-- Filter by game using the `{simId}` key in `tracks`.
-- `path` is relative to `data/` and includes the game folder.
-
 ### Name Format
 
 Both `{SimId}` and `{trackId}` must adhere to the following naming format:
@@ -80,6 +63,25 @@ function nameCleaner($cleanName)
     return $cleanName;
 }   
 ```
+
+### Manifest
+A single root manifest at `data/manifest.json` lists all tracks, grouped by game.
+
+Structure:
+```
+{
+  "tracks": {
+    "{simId}": [
+      { "trackName": "...", "trackId": "...", "path": "{simId}/...json" }
+    ]
+  }
+}
+```
+
+- Filter by game using the `{simId}` key in `tracks`.
+- `path` is relative to `data/` and includes the game folder.
+
+See [scripts/MANIFEST_GENERATOR.md](scripts/MANIFEST_GENERATOR.md) for details on regenerating manifests.
 
 ## Changelog
 Read the [changelog](changelog.md) to keep track of the format updates.
@@ -137,6 +139,13 @@ Every file is formatted as follows:
 ## Contributing
 To maintain properly formatted files, I've implemented - and require - a `pre-commit` script, that will prettify the JSON files and thus properly track changes to them.
 
+### 0. Prerequisite: Python
+The manifest generator runs via Python. Ensure you have Python 3.x available locally (`python3 --version` should work). On macOS you can install it with:
+
+```
+brew install python
+```
+
 ### 1. Install Pre-Commit Hook
 Before you can run hooks, you need to have the pre-commit package manager installed. You can do so by following the instructions on the [official pre-commit website](https://pre-commit.com/#installation), or just install it using the following command:
 
@@ -158,12 +167,13 @@ pre-commit install
 ### 3. Test & Finish
 You're all set as far as tooling is concerned. Every time you make a commit, the `pre-commit` script will make sure the files are properly formatted and are prettified. 
 
-It's usually a good idea to run the hooks against all of the files when adding new hooks (usually pre-commit will only run on the changed files during git hooks). Running `pre-commit run --all-files` will have a pass at everythig, and if all is well, you should see somthing like the below. 
+It's usually a good idea to run the hooks against all of the files when adding new hooks (usually pre-commit will only run on the changed files during git hooks). One of the hooks runs the manifest generator, so you will also see it in the output. Running `pre-commit run --all-files` will have a pass at everything, and if all is well, you should see something like:
 
 ```
 $ pre-commit run --all-files
 check json...............................................................Passed
 pretty format json.......................................................Passed
+Generate data/manifest.json..............................................Passed
 ```
 
 ## Credits


### PR DESCRIPTION
## ci: add manifest enforcement via pre-commit and CI

### Summary
Adds automation to ensure `data/manifest.json` stays in sync with track data files without creating noise commits in `main`.

### Motivation
Currently, contributors must manually run `scripts/generate_manifest.py` before committing. If they forget, the manifest becomes stale. Rather than having CI auto-commit changes (which creates extra commits in `main`), this PR enforces that the manifest is always up-to-date at PR-time.

### What's included
1. **Pre-commit hook** (`.pre-commit-config.yaml`)
   - Automatically runs `generate_manifest.py` on every commit
   - Stages `data/manifest.json` if it changes
   - Ensures developers who have pre-commit installed never forget to update the manifest

2. **CI check** (`.github/workflows/manifest-check.yml`)
   - Runs on PRs and pushes to `main` that touch `scripts/**` or `data/**`
   - Regenerates the manifest and fails if it differs from the committed version
   - Prevents merging PRs with stale manifests

### How it works
- **Local (pre-commit users)**: Manifest auto-generates and stages on commit
- **CI (everyone)**: Pipeline fails if manifest is out-of-date, requiring the contributor to regenerate and push an update

This keeps `main` clean by requiring manifest updates _within the PR_ rather than having CI create follow-up commits.

### Testing
- Added/removed track files trigger manifest regeneration
- CI check passes when manifest is current, fails when stale
- Pre-commit hook runs cleanly without modifying unrelated files